### PR TITLE
Remove clutter

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,9 +12,7 @@
   <description>Demo project for Spring Boot</description>
 
   <properties>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
-    <java.verison>1.8</java.verison>
+    <java.version>1.8</java.version>
   </properties>
 
   <parent>


### PR DESCRIPTION
By fixing java.version the spring-boot-maven plugin sets the correct compiler version.